### PR TITLE
Add Comonad instance for Perhaps

### DIFF
--- a/perhaps.cabal
+++ b/perhaps.cabal
@@ -45,6 +45,7 @@ library
 
   build-depends:
     base                >= 4.3 && < 5,
+    comonad             >= 3.0 && < 6,
     mtl                 >= 2.1 && < 2.3,
     transformers        >= 0.3 && < 0.6,
     transformers-compat >= 0.3 && < 1

--- a/src/Control/Monad/Perhaps.hs
+++ b/src/Control/Monad/Perhaps.hs
@@ -50,6 +50,7 @@ module Control.Monad.Perhaps
 
 import Control.Applicative
 import Control.Exception (Exception(..), throw)
+import Control.Comonad
 import Control.Monad as Monad
 import Control.Monad.Trans
 import Control.Monad.Cont.Class
@@ -193,6 +194,11 @@ instance MonadZip Perhaps where
   mzipWith _ _ (Can't e) = Can't e
   {-# inlinable mzipWith #-}
 #endif
+
+instance Comonad Perhaps where
+  duplicate (Can a) = Can (Can a)
+  duplicate (Can't e) = Can't e
+  extract = believe
 
 -- | This partial function can be used like 'fromJust', but throws the user
 -- error.


### PR DESCRIPTION
While law-abiding in a fast-and-loose sense (we definitely don't have a value of type Void! Everything is fine!) I'll admit that this may be contrary to the intention of the package.

What inspired me to make this is noting that Perhaps is isomorphic to the sum of the identity and void functors.

```haskell
data VoidF a

Perhaps ~ Sum Identity VoidF
```