### PR TITLE
Increment bound on doctest

### DIFF
--- a/perhaps.cabal
+++ b/perhaps.cabal
@@ -70,6 +70,6 @@ test-suite doctests
   build-depends:
     base,
     perhaps,
-    doctest   >= 0.11.1 && <0.16
+    doctest   >= 0.11.1 && <0.17
   ghc-options: -Wall -threaded
   hs-source-dirs: tests


### PR DESCRIPTION
This is breaking the `nixpkgs` package for `perhaps`, as that tries to use doctest `0.16.0` in nixpkgs 18.09.